### PR TITLE
Configuring Realm in Application always

### DIFF
--- a/app/src/main/kotlin/com/arturogutierrez/openticator/application/OpenticatorApplication.kt
+++ b/app/src/main/kotlin/com/arturogutierrez/openticator/application/OpenticatorApplication.kt
@@ -5,13 +5,18 @@ import com.arturogutierrez.openticator.R
 import com.arturogutierrez.openticator.di.component.ApplicationComponent
 import com.arturogutierrez.openticator.di.component.DaggerApplicationComponent
 import com.arturogutierrez.openticator.di.module.ApplicationModule
+import com.arturogutierrez.openticator.domain.bootstrap.StorageInitializator
 import com.crashlytics.android.Crashlytics
 import com.karumi.dexter.Dexter
 import io.fabric.sdk.android.Fabric
+import javax.inject.Inject
 
 class OpenticatorApplication : Application() {
 
   val applicationComponent: ApplicationComponent = DaggerApplicationComponent.builder().applicationModule(ApplicationModule(this)).build()
+
+  @Inject
+  lateinit var storageInitializator: StorageInitializator
 
   override fun onCreate() {
     super.onCreate()
@@ -19,14 +24,24 @@ class OpenticatorApplication : Application() {
   }
 
   private fun initialize() {
+    initializeInjector()
     initializeFabric()
+    initializeStorage()
     initializeDexter()
+  }
+
+  private fun initializeInjector() {
+    applicationComponent.inject(this)
   }
 
   private fun initializeFabric() {
     val packageName = getString(R.string.default_package_name)
     val fabric = Fabric.Builder(this).kits(Crashlytics()).appIdentifier(packageName).build()
     Fabric.with(fabric)
+  }
+
+  private fun initializeStorage() {
+    storageInitializator.configureStorage()
   }
 
   private fun initializeDexter() {

--- a/app/src/main/kotlin/com/arturogutierrez/openticator/di/component/ApplicationComponent.kt
+++ b/app/src/main/kotlin/com/arturogutierrez/openticator/di/component/ApplicationComponent.kt
@@ -3,9 +3,8 @@ package com.arturogutierrez.openticator.di.component
 import android.content.Context
 import android.content.SharedPreferences
 import android.view.LayoutInflater
+import com.arturogutierrez.openticator.application.OpenticatorApplication
 import com.arturogutierrez.openticator.di.module.ApplicationModule
-import com.arturogutierrez.openticator.storage.database.DatabaseConfigurator
-import com.arturogutierrez.openticator.storage.preferences.Preferences
 import com.arturogutierrez.openticator.domain.account.repository.AccountRepository
 import com.arturogutierrez.openticator.domain.category.CategorySelector
 import com.arturogutierrez.openticator.domain.category.repository.CategoryRepository
@@ -13,6 +12,8 @@ import com.arturogutierrez.openticator.domain.issuer.repository.IssuerRepository
 import com.arturogutierrez.openticator.executor.PostExecutionThread
 import com.arturogutierrez.openticator.executor.ThreadExecutor
 import com.arturogutierrez.openticator.storage.clipboard.ClipboardRepository
+import com.arturogutierrez.openticator.storage.database.DatabaseConfigurator
+import com.arturogutierrez.openticator.storage.preferences.Preferences
 import com.arturogutierrez.openticator.view.activity.BaseActivity
 import com.arturogutierrez.openticator.view.activity.ProxyActivity
 import dagger.Component
@@ -21,6 +22,9 @@ import javax.inject.Singleton
 @Singleton
 @Component(modules = arrayOf(ApplicationModule::class))
 interface ApplicationComponent {
+
+  fun inject(application: OpenticatorApplication)
+
   fun inject(proxyActivity: ProxyActivity)
 
   fun inject(baseActivity: BaseActivity)

--- a/app/src/main/kotlin/com/arturogutierrez/openticator/view/activity/ProxyActivity.kt
+++ b/app/src/main/kotlin/com/arturogutierrez/openticator/view/activity/ProxyActivity.kt
@@ -14,8 +14,6 @@ class ProxyActivity : AppCompatActivity() {
   internal lateinit var navigator: Navigator
   @Inject
   internal lateinit var screenSelector: InitialScreenSelector
-  @Inject
-  internal lateinit var storageInitializator: StorageInitializator
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -29,7 +27,6 @@ class ProxyActivity : AppCompatActivity() {
     if (screenSelector.shouldShowWizard()) {
       navigator.goToInitialWizard(this)
     } else {
-      configureApplication()
       navigator.goToAccountList(this)
     }
 
@@ -39,9 +36,5 @@ class ProxyActivity : AppCompatActivity() {
 
   private fun initializeInjector() {
     (application as OpenticatorApplication).applicationComponent.inject(this)
-  }
-
-  private fun configureApplication() {
-    storageInitializator.configureStorage()
   }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,7 +9,7 @@ allprojects {
 ext {
 
   compiler = [java  : JavaVersion.VERSION_1_7,
-              kotlin: '1.0.5']
+              kotlin: '1.0.5-2']
 
   android = [buildTools: '24.0.3',
              compileSdk: 24,
@@ -18,7 +18,7 @@ ext {
 
   build = [gradle       : '2.2.2',
            fabric       : '1.21.4',
-           realm        : '2.0.2',
+           realm        : '2.2.0',
            playPublisher: '1.1.5']
 
   // Google Libraries


### PR DESCRIPTION
Fixes #37 

Realm was not being configured when the activity is rebuilt without pass through ProxyActivity so the configuration is always done in the application when the app starts whenever the reason.