### PR TITLE
Disabling scroll where there is content that doesn’t fit the entire screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
 
+* New: Disabling passcode list scroll when there is content that doesn't fit the entire screen  [#43](https://github.com/arturogutierrez/Openticator/pull/43)
 * Dependencies version updated [#41](https://github.com/arturogutierrez/Openticator/pull/42)
 
 ### 0.8.0 (23/11/2016)

--- a/app/src/main/kotlin/com/arturogutierrez/openticator/domain/account/list/view/AccountListFragment.kt
+++ b/app/src/main/kotlin/com/arturogutierrez/openticator/domain/account/list/view/AccountListFragment.kt
@@ -14,6 +14,8 @@ import com.arturogutierrez.openticator.domain.account.list.adapter.AccountViewHo
 import com.arturogutierrez.openticator.domain.account.list.adapter.AccountsAdapter
 import com.arturogutierrez.openticator.domain.account.list.di.AccountListComponent
 import com.arturogutierrez.openticator.domain.account.model.AccountPasscode
+import com.arturogutierrez.openticator.helpers.disableAppBarLayoutScroll
+import com.arturogutierrez.openticator.helpers.enableAppBarLayoutScroll
 import com.arturogutierrez.openticator.view.fragment.BaseFragment
 import com.arturogutierrez.openticator.view.fragment.makeSnackbar
 import com.arturogutierrez.openticator.view.widget.gone
@@ -104,6 +106,7 @@ class AccountListFragment : BaseFragment(), AccountListView {
 
   private fun showAccountList(accounts: List<AccountPasscode>) {
     updateAccounts(accounts)
+    updateScrollBasedOnContent(accounts)
 
     rvAccounts.visible()
     tvEmptyView.gone()
@@ -118,5 +121,14 @@ class AccountListFragment : BaseFragment(), AccountListView {
 
   private fun updateAccounts(accounts: List<AccountPasscode>) {
     accountsAdapter.accounts = accounts
+  }
+
+  private fun updateScrollBasedOnContent(accounts: List<AccountPasscode>) {
+    val layoutManager = rvAccounts.layoutManager as LinearLayoutManager
+    if (layoutManager.findLastCompletelyVisibleItemPosition() == accounts.size - 1) {
+      activity.disableAppBarLayoutScroll()
+    } else {
+      activity.enableAppBarLayoutScroll()
+    }
   }
 }

--- a/app/src/main/kotlin/com/arturogutierrez/openticator/helpers/ActivityExt.kt
+++ b/app/src/main/kotlin/com/arturogutierrez/openticator/helpers/ActivityExt.kt
@@ -1,0 +1,50 @@
+package com.arturogutierrez.openticator.helpers
+
+import android.app.Activity
+import android.support.design.widget.AppBarLayout
+import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
+import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
+import android.support.design.widget.CoordinatorLayout
+import com.arturogutierrez.openticator.R
+
+fun Activity.disableAppBarLayoutScroll() {
+  val toolbar = findViewById(R.id.toolbar)
+  val appBarLayout = findViewById(R.id.appbar_layout)
+
+  if (toolbar == null || appBarLayout == null) {
+    return
+  }
+
+  toolbar.apply {
+    val toolbarLayoutParams = toolbar.layoutParams as AppBarLayout.LayoutParams
+    toolbarLayoutParams.scrollFlags = 0
+    layoutParams = toolbarLayoutParams
+  }
+
+  appBarLayout.apply {
+    val appBarLayoutParams = appBarLayout.layoutParams as CoordinatorLayout.LayoutParams
+    appBarLayoutParams.behavior = null
+    layoutParams = appBarLayoutParams
+  }
+}
+
+fun Activity.enableAppBarLayoutScroll() {
+  val toolbar = findViewById(R.id.toolbar)
+  val appBarLayout = findViewById(R.id.appbar_layout)
+
+  if (toolbar == null || appBarLayout == null) {
+    return
+  }
+
+  toolbar.apply {
+    val toolbarLayoutParams = toolbar.layoutParams as AppBarLayout.LayoutParams
+    toolbarLayoutParams.scrollFlags = SCROLL_FLAG_SCROLL or SCROLL_FLAG_ENTER_ALWAYS
+    layoutParams = toolbarLayoutParams
+  }
+
+  appBarLayout.apply {
+    val appBarLayoutParams = appBarLayout.layoutParams as CoordinatorLayout.LayoutParams
+    appBarLayoutParams.behavior = AppBarLayout.Behavior()
+    layoutParams = appBarLayoutParams
+  }
+}


### PR DESCRIPTION
Fixes #26 

The idea is about enabling or disabling the `AppBarLayout` scroll when the last row in the main `RecyclerView` is visible or not.