### PR TITLE
Using allopen plugin for Realm models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Stateless interactors [#62](https://github.com/arturogutierrez/Openticator/pull/62)
 * Removing abstract layout resource from BaseActivity [#63](https://github.com/arturogutierrez/Openticator/pull/63)
 * First Espresso tests [#64](https://github.com/arturogutierrez/Openticator/pull/64)
+* Using allopen plugin for Realm models [#67](https://github.com/arturogutierrez/Openticator/pull/67)
 
 ### 0.9.3 (13/12/2016)
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
     classpath buildPlugins.gradle
     classpath buildPlugins.kotlin
+    classpath buildPlugins.kotlinAllOpen
     classpath buildPlugins.realm
     classpath buildPlugins.fabric
     classpath buildPlugins.playPublisher

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-allopen'
 apply plugin: 'realm-android'
 
 android {
@@ -32,6 +33,10 @@ android {
   lintOptions {
     ignore 'InvalidPackage'
   }
+}
+
+allOpen {
+  annotation("com.arturogutierrez.openticator.storage.realm.model.RealmModel")
 }
 
 dependencies {

--- a/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/model/AccountRealm.kt
+++ b/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/model/AccountRealm.kt
@@ -3,7 +3,8 @@ package com.arturogutierrez.openticator.storage.realm.model
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 
-open class AccountRealm : RealmObject() {
+@RealmModel
+class AccountRealm : RealmObject() {
 
   companion object {
     val TOTP_TYPE = "TOTP"
@@ -11,11 +12,11 @@ open class AccountRealm : RealmObject() {
   }
 
   @PrimaryKey
-  open var accountId: String = ""
-  open var name: String = ""
-  open var type: String = ""
-  open var secret: String = ""
-  open var issuer: String = ""
-  open var order: Int = 0
-  open var category: CategoryRealm? = null
+  var accountId: String = ""
+  var name: String = ""
+  var type: String = ""
+  var secret: String = ""
+  var issuer: String = ""
+  var order: Int = 0
+  var category: CategoryRealm? = null
 }

--- a/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/model/CategoryRealm.kt
+++ b/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/model/CategoryRealm.kt
@@ -3,9 +3,10 @@ package com.arturogutierrez.openticator.storage.realm.model
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
 
-open class CategoryRealm : RealmObject() {
+@RealmModel
+class CategoryRealm : RealmObject() {
 
   @PrimaryKey
-  open var categoryId: String = ""
-  open var name: String = ""
+  var categoryId: String = ""
+  var name: String = ""
 }

--- a/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/model/RealmModel.kt
+++ b/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/model/RealmModel.kt
@@ -1,0 +1,3 @@
+package com.arturogutierrez.openticator.storage.realm.model
+
+annotation class RealmModel

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,6 +61,7 @@ ext {
 
   buildPlugins = [gradle       : "com.android.tools.build:gradle:$build.gradle",
                   kotlin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$compiler.kotlin",
+                  kotlinAllOpen: "org.jetbrains.kotlin:kotlin-allopen:$compiler.kotlin",
                   realm        : "io.realm:realm-gradle-plugin:$build.realm",
                   fabric       : "io.fabric.tools:gradle:$build.fabric",
                   playPublisher: "com.github.triplet.gradle:play-publisher:$build.playPublisher"]


### PR DESCRIPTION
Realm needs all models are non-finals in order to modify them at compile time. Since JetBrains launched the `allopen` plugin in Kotlin 1.0.6 I can use it for my Realm models to avoid to write those `open` manually.