### PR TITLE
Propagating build variant to Android Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Using allopen plugin for Realm models [#67](https://github.com/arturogutierrez/Openticator/pull/67)
 * Stetho support [#69](https://github.com/arturogutierrez/Openticator/pull/69)
 * Realm migrations support [#70](https://github.com/arturogutierrez/Openticator/pull/70)
+* Propagating build variant to Android Module [#71](https://github.com/arturogutierrez/Openticator/pull/71)
 
 ### 0.9.4 (02/01/2017)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,7 +109,8 @@ dependencies {
   def presentationTestDependencies = rootProject.ext.presentationTestDependencies
 
   compile project(':domain')
-  compile project(':data')
+  debugCompile project(path: ':data', configuration: 'debug')
+  releaseCompile project(path: ':data', configuration: 'release')
 
   compile presentationDependencies.multiDex
   compile presentationDependencies.flowUp

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -13,6 +13,9 @@ android {
     minSdkVersion ext.android.minSdk
     targetSdkVersion ext.android.targetSdk
     versionCode ext.application.versionCode
+
+    defaultPublishConfig 'release'
+    publishNonDefault true
   }
 
   sourceSets {

--- a/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/RealmDatabaseConfigurator.kt
+++ b/data/src/main/kotlin/com/arturogutierrez/openticator/storage/realm/RealmDatabaseConfigurator.kt
@@ -6,7 +6,6 @@ import com.arturogutierrez.openticator.storage.database.DatabaseConfigurator
 import com.arturogutierrez.openticator.storage.realm.migration.RealmMigrationManager
 import io.realm.Realm
 import io.realm.RealmConfiguration
-import io.realm.RealmMigration
 import javax.inject.Inject
 
 class RealmDatabaseConfigurator @Inject constructor(private val context: Context) : DatabaseConfigurator {


### PR DESCRIPTION
Build variant is not propagated to Android modules automatically (view issue: https://code.google.com/p/android/issues/detail?id=52962) so it's needed to select the right build variant for Debug and Release variants manually 😑

```groovy
  debugCompile project(path: ':data', configuration: 'debug')
  releaseCompile project(path: ':data', configuration: 'release')
```

This way I'm saving to build the Android module(`data`) in Debug and Release both on all builds.